### PR TITLE
Correct typo in the word "Latitude" in Geoposition class.

### DIFF
--- a/PoliceUK.Tests.Integrated/PoliceUkClientTests.cs
+++ b/PoliceUK.Tests.Integrated/PoliceUkClientTests.cs
@@ -215,7 +215,7 @@
 
             IEnumerable<Geoposition> positions = policeApi.NeighbourhoodBoundary("", NeighbourhoodId);
 
-            // Assert
+            // Assertpol
             Assert.IsNull(positions);
         }
 

--- a/PoliceUK.Tests.Integrated/PoliceUkClientTests.cs
+++ b/PoliceUK.Tests.Integrated/PoliceUkClientTests.cs
@@ -215,7 +215,7 @@
 
             IEnumerable<Geoposition> positions = policeApi.NeighbourhoodBoundary("", NeighbourhoodId);
 
-            // Assertpol
+            // Assert
             Assert.IsNull(positions);
         }
 

--- a/PoliceUK.Tests.Unit/CrimesAtLocationTests.cs
+++ b/PoliceUK.Tests.Unit/CrimesAtLocationTests.cs
@@ -81,7 +81,7 @@
             //        policeApi.StreetLevelCrimes(geoPosition);
 
             //        // Assert
-            //        string latitude  = geoPosition.Latitiude.ToString();
+            //        string latitude  = geoPosition.Latitude.ToString();
             //        string longitude = geoPosition.Longitude.ToString();
 
             //        IHttpWebRequestFactory factory = policeApi.RequestFactory;
@@ -166,7 +166,7 @@
                     policeApi.CrimesAtLocation(geoPosition, DateTime.Now);
 
                     // Assert
-                    string latitude = geoPosition.Latitiude.ToString();
+                    string latitude = geoPosition.Latitude.ToString();
                     string longitude = geoPosition.Longitude.ToString();
 
                     IHttpWebRequestFactory factory = policeApi.RequestFactory;

--- a/PoliceUK.Tests.Unit/CrimesTests.cs
+++ b/PoliceUK.Tests.Unit/CrimesTests.cs
@@ -80,7 +80,7 @@
         //        policeApi.StreetLevelCrimes(geoPosition);
 
         //        // Assert
-        //        string latitude  = geoPosition.Latitiude.ToString();
+        //        string latitude  = geoPosition.Latitude.ToString();
         //        string longitude = geoPosition.Longitude.ToString();
 
         //        IHttpWebRequestFactory factory = policeApi.RequestFactory;

--- a/PoliceUK.Tests.Unit/CustomAssertions/Equality/GeoPositionEqualityComparer.cs
+++ b/PoliceUK.Tests.Unit/CustomAssertions/Equality/GeoPositionEqualityComparer.cs
@@ -6,7 +6,7 @@
     {
         public override bool AreEqual(Geoposition GeopositionOne, Geoposition GeopositionTwo)
         {
-            Assert.AreEqual(GeopositionOne.Latitiude, GeopositionTwo.Latitiude);
+            Assert.AreEqual(GeopositionOne.Latitude, GeopositionTwo.Latitude);
             Assert.AreEqual(GeopositionOne.Longitude, GeopositionTwo.Longitude);            
 
             return true;

--- a/PoliceUK.Tests.Unit/CustomAssertions/Equality/NeighbourhoodDetails/NeighbourhoodDetailsEqualityComparer.cs
+++ b/PoliceUK.Tests.Unit/CustomAssertions/Equality/NeighbourhoodDetails/NeighbourhoodDetailsEqualityComparer.cs
@@ -17,7 +17,7 @@
 
             if (NeighbourhoodDetailsOne.Centre != null || NeighbourhoodDetailsTwo.Centre != null)
             {
-                Assert.AreEqual(NeighbourhoodDetailsOne.Centre.Latitiude, NeighbourhoodDetailsTwo.Centre.Latitiude);
+                Assert.AreEqual(NeighbourhoodDetailsOne.Centre.Latitude, NeighbourhoodDetailsTwo.Centre.Latitude);
                 Assert.AreEqual(NeighbourhoodDetailsOne.Centre.Longitude, NeighbourhoodDetailsTwo.Centre.Longitude);
             }
 

--- a/PoliceUK.Tests.Unit/StreetLevelCrimesTests.cs
+++ b/PoliceUK.Tests.Unit/StreetLevelCrimesTests.cs
@@ -77,7 +77,7 @@
                     policeApi.StreetLevelCrimes(geoPosition);
 
                     // Assert
-                    string latitude  = geoPosition.Latitiude.ToString();
+                    string latitude  = geoPosition.Latitude.ToString();
                     string longitude = geoPosition.Longitude.ToString();
 
                     IHttpWebRequestFactory factory = policeApi.RequestFactory;

--- a/PoliceUK/Geoposition.cs
+++ b/PoliceUK/Geoposition.cs
@@ -2,13 +2,13 @@ namespace PoliceUk
 {
     public class Geoposition : IGeoposition
     {
-        public double Latitiude {get; private set;}
+        public double Latitude {get; private set;}
 
         public double Longitude {get; private set;}
 
         public Geoposition(double latitude, double longitude)
         {
-            this.Latitiude = latitude;
+            this.Latitude = latitude;
             this.Longitude = longitude;
         }
     }

--- a/PoliceUK/IGeoposition.cs
+++ b/PoliceUK/IGeoposition.cs
@@ -2,7 +2,7 @@
 {
     public interface IGeoposition 
     {
-        double Latitiude {get;}
+        double Latitude {get;}
 
         double Longitude {get;}
     }

--- a/PoliceUK/PoliceUkClient.cs
+++ b/PoliceUK/PoliceUkClient.cs
@@ -29,7 +29,7 @@
             }
 
             string url = string.Format("{0}crimes-street/all-crime?lat={1}&lng={2}", ApiPath,
-                position.Latitiude,
+                position.Latitude,
                 position.Longitude);
 
             if (date.HasValue) url += string.Format("&date={0:yyyy'-'MM}", date.Value);
@@ -55,7 +55,7 @@
             string url = string.Format("{0}crimes-street/all-crime", ApiPath);
 
             // Post data
-            IEnumerable<string> polygonSections = polygon.Select(T => T.Latitiude.ToString() + "," + T.Longitude.ToString());
+            IEnumerable<string> polygonSections = polygon.Select(T => T.Latitude.ToString() + "," + T.Longitude.ToString());
             string postData = "poly=" + string.Join(":", polygonSections.ToArray());
             if (date.HasValue) postData += string.Format("&date={0:yyyy'-'MM}", date.Value);
 
@@ -199,7 +199,7 @@
             }
 
             string url = string.Format("{0}locate-neighbourhood?q={1},{2}", ApiPath,
-                position.Latitiude, 
+                position.Latitude, 
                 position.Longitude);
 
             IHttpWebRequest request = BuildGetWebRequest(url);
@@ -256,7 +256,7 @@
             }
 
             string url = string.Format("{0}crimes-at-location?lat={1}&lng={2}&date={3:yyyy'-'MM}", ApiPath,
-                position.Latitiude,
+                position.Latitude,
                 position.Longitude,
                 date);
 


### PR DESCRIPTION
Correct typo: Latitiude => Latitude